### PR TITLE
Add high speed mode

### DIFF
--- a/launch/ps4.launch
+++ b/launch/ps4.launch
@@ -13,14 +13,15 @@
 
   <node pkg="joystick_interrupt" type="joystick_interrupt" name="joystick_interrupt">
     <param name="interrupt_button" value="6" type="int" />
-    <param name="high_speed_button" value="4" type="int" />
+    <param name="high_speed_button" value="-1" type="int" />
     <param name="linear_axis" value="1" type="int" />
     <param name="angular_axis" value="0" type="int" />
     <param name="linear_axis2" value="10" type="int" />
     <param name="angular_axis2" value="9" type="int" />
     <param name="linear_vel" value="$(arg linear_vel)" type="double" />
     <param name="angular_vel" value="$(arg angular_vel)" type="double" />
-    <param name="high_speed_ratio" value="1.5" type="double" />
+    <param name="linear_high_speed_ratio" value="1.3" type="double" />
+    <param name="angular_high_speed_ratio" value="1.1" type="double" />
     <remap from="~/cmd_vel" to="$(arg cmd_vel_out)" />
     <remap from="~/cmd_vel_input" to="$(arg cmd_vel_in)" />
     <remap from="/joy" to="/joystick_interrupt/joy" />

--- a/launch/ps4.launch
+++ b/launch/ps4.launch
@@ -13,12 +13,14 @@
 
   <node pkg="joystick_interrupt" type="joystick_interrupt" name="joystick_interrupt">
     <param name="interrupt_button" value="6" type="int" />
+    <param name="high_speed_button" value="4" type="int" />
     <param name="linear_axis" value="1" type="int" />
     <param name="angular_axis" value="0" type="int" />
     <param name="linear_axis2" value="10" type="int" />
     <param name="angular_axis2" value="9" type="int" />
     <param name="linear_vel" value="$(arg linear_vel)" type="double" />
     <param name="angular_vel" value="$(arg angular_vel)" type="double" />
+    <param name="high_speed_ratio" value="1.5" type="double" />
     <remap from="~/cmd_vel" to="$(arg cmd_vel_out)" />
     <remap from="~/cmd_vel_input" to="$(arg cmd_vel_in)" />
     <remap from="/joy" to="/joystick_interrupt/joy" />

--- a/src/joystick_interrupt.cpp
+++ b/src/joystick_interrupt.cpp
@@ -131,7 +131,7 @@ public:
     pnh_.param("linear_axis2", linear_axis2_, -1);
     pnh_.param("angular_axis2", angular_axis2_, -1);
     pnh_.param("interrupt_button", interrupt_button_, 6);
-    pnh_.param("high_speed_button", high_speed_button_, 4);
+    pnh_.param("high_speed_button", high_speed_button_, -1);
     pnh_.param("linear_high_speed_ratio", linear_high_speed_ratio_, 1.3);
     pnh_.param("angular_high_speed_ratio", angular_high_speed_ratio_, 1.1);
     pnh_.param("timeout", timeout_, 0.5);

--- a/src/joystick_interrupt.cpp
+++ b/src/joystick_interrupt.cpp
@@ -44,11 +44,13 @@ private:
   double linear_vel_;
   double angular_vel_;
   double timeout_;
+  double high_speed_ratio_;
   int linear_axis_;
   int angular_axis_;
   int linear_axis2_;
   int angular_axis2_;
   int interrupt_button_;
+  int high_speed_button_;
   ros::Time last_joy_msg_;
 
   void cbJoy(const sensor_msgs::Joy::Ptr msg)
@@ -72,6 +74,15 @@ private:
         if (fabs(msg->axes[angular_axis2_]) > fabs(lin))
         {
           ang = msg->axes[angular_axis2_];
+        }
+      }
+
+      if (high_speed_button_ >= 0)
+      {
+        if (msg->buttons[high_speed_button_])
+        {
+          lin *= high_speed_ratio_;
+          ang *= high_speed_ratio_;
         }
       }
 
@@ -119,6 +130,8 @@ public:
     pnh_.param("linear_axis2", linear_axis2_, -1);
     pnh_.param("angular_axis2", angular_axis2_, -1);
     pnh_.param("interrupt_button", interrupt_button_, 6);
+    pnh_.param("high_speed_button", high_speed_button_, 4);
+    pnh_.param("high_speed_ratio", high_speed_ratio_, 1.5);
     pnh_.param("timeout", timeout_, 0.5);
     last_joy_msg_ = ros::Time(0);
   }

--- a/src/joystick_interrupt.cpp
+++ b/src/joystick_interrupt.cpp
@@ -44,7 +44,8 @@ private:
   double linear_vel_;
   double angular_vel_;
   double timeout_;
-  double high_speed_ratio_;
+  double linear_high_speed_ratio_;
+  double angular_high_speed_ratio_;
   int linear_axis_;
   int angular_axis_;
   int linear_axis2_;
@@ -81,8 +82,8 @@ private:
       {
         if (msg->buttons[high_speed_button_])
         {
-          lin *= high_speed_ratio_;
-          ang *= high_speed_ratio_;
+          lin *= linear_high_speed_ratio_;
+          ang *= angular_high_speed_ratio_;
         }
       }
 
@@ -131,7 +132,8 @@ public:
     pnh_.param("angular_axis2", angular_axis2_, -1);
     pnh_.param("interrupt_button", interrupt_button_, 6);
     pnh_.param("high_speed_button", high_speed_button_, 4);
-    pnh_.param("high_speed_ratio", high_speed_ratio_, 1.5);
+    pnh_.param("linear_high_speed_ratio", linear_high_speed_ratio_, 1.3);
+    pnh_.param("angular_high_speed_ratio", angular_high_speed_ratio_, 1.1);
     pnh_.param("timeout", timeout_, 0.5);
     last_joy_msg_ = ros::Time(0);
   }


### PR DESCRIPTION
Add high speed mode to speed up linear and angular velocity.

The mode is enabled by pushing 'high_speed_button' (default 4, L1 button on PS4), and disabled by passing 'high_speed_button' parameter by -1 at startup.